### PR TITLE
[FIXED] outdated pip warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,19 +8,19 @@ services:
   autogen-profiles:
     image: python:3.8-slim-buster
     container_name: autogen-profiles.complexdatalabmcgill.github.io
-    environment: 
+    environment:
       - DATA_ROOT=/data
     volumes:
       - ./scripts:/run
       - ./_data:/data/_data
       - ./_members:/data/_members
     working_dir: /run
-    command: bash -c "pip install -q pyyaml tqdm && ./autogen_profiles"
+    command: bash -c "/usr/local/bin/python -m pip install --upgrade pip && pip install -q pyyaml tqdm && ./autogen_profiles"
 
-  jekyll: 
+  jekyll:
     image: jekyll/jekyll:3.8
     container_name: complexdatalabmcgill.github.io
-    depends_on: 
+    depends_on:
       - "autogen-profiles"
     environment:
         - JEKYLL_ENV=docker


### PR DESCRIPTION
Fixed the following warning: 

```
autogen-profiles.complexdatalabmcgill.github.io | WARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.           
autogen-profiles.complexdatalabmcgill.github.io | You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' 
command
``
`

(not sure if there's a fancier way to do it, though)